### PR TITLE
Use mobile friendly Facebook sharing script

### DIFF
--- a/src/Providers/Facebook.php
+++ b/src/Providers/Facebook.php
@@ -9,15 +9,14 @@ class Facebook extends ProviderBase implements ProviderInterface
     public function shareUrl()
     {
         return $this->buildUrl(
-            'https://www.facebook.com/sharer.php',
+            'https://www.facebook.com/sharer/sharer.php',
             array(
-                'url' => 'p[url]',
-                'title' => 'p[title]',
-                'text' => 'p[summary]',
-                'image' => 'p[images][0]',
+                'url' => 'u',
+                'title' => 't',
             ),
             array(
-                's' => 100,
+                'display' => 'popup',
+                'redirect_uri' => 'http://www.facebook.com'
             )
         );
     }


### PR DESCRIPTION
The currently used facebook share script does not work on mobile devices. It redirects to the "new" script which has different URL parameters and therefore does not correctly share the link.

Unfortunately, the "new" script does not allow to pass customized data like text and image, but it will read og: meta tags for that information. I don't think there's a solution for that though…