### PR TITLE
Add caching and allow share count totals over multiple providers and/or multiple URLs.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,8 @@
 		"issues": "https://github.com/oscarotero/social-links/issues"
 	},
 	"require": {
-		"php": ">=5.3.0"
+		"php": ">=5.3.0",
+		"doctrine/cache": "^1.7"
 	},
 	"autoload": {
 		"psr-4": {

--- a/src/Page.php
+++ b/src/Page.php
@@ -251,6 +251,16 @@ class Page
     }
 
     /**
+     * Gets the page url.
+     *
+     * @return array|null
+     */
+    public function getUrls()
+    {
+        return $this->info['urls'];
+    }
+
+    /**
      * Gets the page title.
      *
      * @return string|null
@@ -363,5 +373,15 @@ class Page
     public function getId($provider)
     {
         return sprintf('%s_%s', $provider, $this->info['url']);
+    }
+
+    /**
+     * Checks if there are multiple URLs.
+     *
+     * @return bool
+     */
+    public function isMultiple()
+    {
+        return !empty($this->getUrls());
     }
 }

--- a/src/Page.php
+++ b/src/Page.php
@@ -161,9 +161,9 @@ class Page
             // Check cache, if option is set.
             if ($this->getConfig('useCache')) {
                 $id = $this->getId($provider);
-                if ($cachedData = $this->page->cache->fetch($id)) {
+                if ($cachedData = $this->cache->fetch($id)) {
                     $expired = empty($cachedData[1]) || (
-                        $cachedData[1] + $this->page->getConfig('cacheDuration') < $now
+                        $cachedData[1] + $this->getConfig('cacheDuration') < $now
                     );
 
                     // If not expired, set shareCount and return.

--- a/src/Page.php
+++ b/src/Page.php
@@ -3,6 +3,7 @@
 namespace SocialLinks;
 
 use Doctrine\Common\Cache\Cache;
+use Doctrine\Common\Cache\PhpFileCache;
 
 /**
  * @method html()
@@ -33,16 +34,19 @@ class Page
      *
      * @param array $info   The page info. Only url, title, text, image, icon and twitterUser fields are available
      * @param array $config Configuration options
+     * @param Cache $cache Doctrine Cache instance, defaults to a new PhpFileCache
      */
-    public function __construct(array $info, array $config = array(), Cache $cache)
+    public function __construct(array $info, array $config = array(), Cache $cache = NULL)
     {
+        $cache = $cache ?: new PhpFileCache(sys_get_temp_dir());
+
         if (array_diff_key($info, $this->info)) {
             throw new \Exception('Only the following fields are available:'.implode(',', array_keys($this->info)));
         }
 
         $this->info = array_map('static::normalize', $info + $this->info);
 
-        $this->config = $config;
+        $this->config = array_map('static::normalize', $config + $this->config);
         $this->cache = $cache;
     }
 

--- a/src/Page.php
+++ b/src/Page.php
@@ -154,7 +154,7 @@ class Page
     /**
      * Preload the counter.
      *
-     * @param array $providers
+     * @param array $providers Array of providers - defaults to all.
      */
     public function shareCount(array $providers)
     {

--- a/src/Page.php
+++ b/src/Page.php
@@ -22,6 +22,7 @@ class Page
     protected $metas = array();
     protected $info = array(
         'url' => null,
+        'urls' => array(),
         'title' => null,
         'text' => null,
         'image' => null,
@@ -63,7 +64,14 @@ class Page
      */
     protected static function normalize($value)
     {
-        return trim(strip_tags(htmlspecialchars_decode(preg_replace('/\s+/', ' ', $value))));
+        if (is_array($value)) {
+            return array_map(function ($v) {
+                return trim(strip_tags(htmlspecialchars_decode(preg_replace('/\s+/', ' ', $v))));
+            }, $value);
+        }
+        else {
+            return trim(strip_tags(htmlspecialchars_decode(preg_replace('/\s+/', ' ', $value))));
+        }
     }
 
     /**

--- a/src/Page.php
+++ b/src/Page.php
@@ -182,7 +182,12 @@ class Page
                 }
             }
 
-            $request = $this->$provider->shareCountRequest();
+            if ($this->isMultiple()) {
+                $request = $this->$provider->shareCountRequestMultiple();
+            }
+            else {
+                $request = $this->$provider->shareCountRequest();
+            }
 
             if ($request !== null) {
                 $connections[$provider] = $request;
@@ -207,7 +212,12 @@ class Page
         }
 
         foreach ($connections as $provider => $request) {
-            $this->$provider->shareCount = $this->$provider->shareCount(curl_multi_getcontent($request));
+            if ($this->isMultiple()) {
+                $this->$provider->shareCount = $this->$provider->shareCountMultiple(curl_multi_getcontent($request));
+            }
+            else {
+                $this->$provider->shareCount = $this->$provider->shareCount(curl_multi_getcontent($request));
+            }
 
             curl_multi_remove_handle($curl, $request);
 
@@ -235,7 +245,12 @@ class Page
 
         $shareCountTotal = 0;
         foreach ($providers as $provider) {
-            $shareCountTotal += $this->$provider->shareCount;
+            if ($this->isMultiple()) {
+                $shareCountTotal += array_sum($this->$provider->shareCount);
+            }
+            else {
+                $shareCountTotal += $this->$provider->shareCount;
+            }
         }
         return $shareCountTotal;
     }

--- a/src/Providers/Facebook.php
+++ b/src/Providers/Facebook.php
@@ -47,4 +47,32 @@ class Facebook extends ProviderBase implements ProviderInterface
 
         return isset($count['share']['share_count']) ? intval($count['share']['share_count']) : 0;
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function shareCountRequestMultiple()
+    {
+        return static::request(
+            $this->buildUrl(
+                'https://graph.facebook.com/',
+                array(),
+                array(
+                    'ids' => implode(',', $this->page->getUrls())
+                )
+            )
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function shareCountMultiple($response)
+    {
+        $count_array = self::jsonResponse($response);
+
+        return array_map(function ($count) {
+            return isset($count['share']['share_count']) ? intval($count['share']['share_count']) : 0;
+        }, $count_array);
+    }
 }

--- a/src/Providers/ProviderBase.php
+++ b/src/Providers/ProviderBase.php
@@ -138,6 +138,8 @@ abstract class ProviderBase
      * @param array  $pageParams parameters to be taken from page fields as $paramName  => $paramNameInTheURL
      * @param array  $getParams  extra parameters as $key => $value
      * @param int    $encoding   Type of encoding used. It can be static::RFC3986 or static::RFC1738
+     *
+     * @return string
      */
     protected function buildUrl($url, array $pageParams = null, array $getParams = array(), $encoding = self::RFC1738)
     {

--- a/src/Providers/ProviderBase.php
+++ b/src/Providers/ProviderBase.php
@@ -101,6 +101,27 @@ abstract class ProviderBase
     }
 
     /**
+     * Default shareCountMultiple function for providers without count api.
+     *
+     * {@inheritdoc}
+     */
+    public function shareCountMultiple($response)
+    {
+        return;
+    }
+
+    /**
+     * Default shareCountRequestMultiple function for providers without
+     * count api.
+     *
+     * {@inheritdoc}
+     */
+    public function shareCountRequestMultiple()
+    {
+        return;
+    }
+
+    /**
      * Generates a valid url.
      *
      * @param string $url

--- a/src/Providers/ProviderBase.php
+++ b/src/Providers/ProviderBase.php
@@ -60,13 +60,23 @@ abstract class ProviderBase
                     }
                 }
 
-                $request = $this->shareCountRequest();
+                if ($this->page->isMultiple()) {
+                    $request = $this->shareCountRequestMultiple();
+                }
+                else {
+                    $request = $this->shareCountRequest();
+                }
 
                 if ($request !== null) {
                     $response = curl_exec($request) ?: '';
                     curl_close($request);
 
-                    $this->shareCount = $this->shareCount($response);
+                    if ($this->page->isMultiple()) {
+                        $this->shareCount = $this->shareCountMultiple($response);
+                    }
+                    else {
+                        $this->shareCount = $this->shareCount($response);
+                    }
 
                     // Save in cache, if option is set.
                     if ($this->page->getConfig('useCache')) {

--- a/src/Providers/ProviderInterface.php
+++ b/src/Providers/ProviderInterface.php
@@ -26,4 +26,20 @@ interface ProviderInterface
      * @return resource|null
      */
     public function shareCountRequest();
+
+    /**
+     * Returns the share count for multiple URLs.
+     *
+     * @param string $response Request response body
+     *
+     * @return array|null
+     */
+    public function shareCountMultiple($response);
+
+    /**
+     * Returns a curl resource used to count shares for multiple URLs.
+     *
+     * @return resource|null
+     */
+    public function shareCountRequestMultiple();
 }


### PR DESCRIPTION
I've added Doctrine Cache to store share count results. I also added the ability to specify multiple URLs for a Page (thought it wouldn't make sense in the share link generation aspect of things) to enable looping over the URLs when getting share counts.