### PR TITLE
Change whatsapp share URL

### DIFF
--- a/src/Providers/Whatsapp.php
+++ b/src/Providers/Whatsapp.php
@@ -12,7 +12,7 @@ class Whatsapp extends ProviderBase implements ProviderInterface
         $info = $this->page->get();
 
         return $this->buildUrl(
-            'whatsapp://send',
+            'https://wa.me',
             null,
             array(
                 'text' => $info['title'].' '.$info['url'],

--- a/tests/BasicTest.php
+++ b/tests/BasicTest.php
@@ -69,7 +69,7 @@ class BasicTest extends TestCase
         $this->assertEquals($page->tumblr->shareUrl, 'https://www.tumblr.com/share?v=3&u=http%3A%2F%2Fmypage.com&t=Page+title');
         $this->assertEquals($page->twitter->shareUrl, 'https://twitter.com/intent/tweet?text=Page+title+via+%40twitterUser&url=http%3A%2F%2Fmypage.com');
         $this->assertEquals($page->vk->shareUrl, 'http://vk.com/share.php?url=http%3A%2F%2Fmypage.com&title=Page+title&image=http%3A%2F%2Fmypage.com%2Fimage.png');
-        $this->assertEquals($page->whatsapp->shareUrl, 'whatsapp://send?text=Page+title+http%3A%2F%2Fmypage.com');
+        $this->assertEquals($page->whatsapp->shareUrl, 'https://wa.me/?text=Page+title+http%3A%2F%2Fmypage.com');
         $this->assertEquals($page->telegram->shareUrl, 'tg://msg?text=Page+title+http%3A%2F%2Fmypage.com');
         $this->assertEquals($page->xing->shareUrl, 'https://www.xing.com/spi/shares/new?url=http%3A%2F%2Fmypage.com');
         $this->assertEquals($page->viadeo->shareUrl, 'https://partners.viadeo.com/share?url=http%3A%2F%2Fmypage.com&comment=Page+title');


### PR DESCRIPTION
Changing the URL from "whatsapp://send" to "https://wa.me"
This seems to work well with and without the whatsapp installed