### PR TITLE
whatsapp link for compatibility with mobile and desktop

### DIFF
--- a/src/Providers/Whatsapp.php
+++ b/src/Providers/Whatsapp.php
@@ -12,7 +12,7 @@ class Whatsapp extends ProviderBase implements ProviderInterface
         $info = $this->page->get();
 
         return $this->buildUrl(
-            'https://wa.me/',
+            'https://api.whatsapp.com/send',
             null,
             array(
                 'text' => $info['title'].' '.$info['url'],


### PR DESCRIPTION
The existing whatsapp link seems not working on desktop environments.
I've changed the url to the whatsapp api which works with mobile and desktop browsers.